### PR TITLE
Bugfix: Consider bundleId passed as parameter

### DIFF
--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -14,12 +14,13 @@ module Fastlane
         UI.message "Version: #{params[:version]}"
         UI.message "Server URL: #{params[:server]}"
 
-        UI.message("Checking AppFile for possible AppID")
-        bundleId = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
-        UI.message("Using #{bundleId} from your AppFile")
-
-        if !(bundleId)
-          UI.message "BundleID: #{params[:bundleId]}"
+        bundleId = params[:bundleId]
+        if (bundleId)
+          UI.message "BundleID: #{bundleId}"
+        else
+          UI.message "Checking AppFile for possible AppID"
+          bundleId = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
+          UI.message "Using #{bundleId} from your AppFile"
         end
 
 

--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -14,13 +14,13 @@ module Fastlane
         UI.message "Version: #{params[:version]}"
         UI.message "Server URL: #{params[:server]}"
 
-        bundleId = params[:bundleId]
+        UI.message "Checking AppFile for possible AppID"
+        bundleId = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
         if (bundleId)
-          UI.message "BundleID: #{bundleId}"
-        else
-          UI.message "Checking AppFile for possible AppID"
-          bundleId = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
           UI.message "Using #{bundleId} from your AppFile"
+        else
+          bundleId = params[:bundleId]
+          UI.message "BundleID: #{bundleId}"
         end
 
 


### PR DESCRIPTION
The current implementation prints `bundleId` passed as a parameter but doesn't use it in the client command. 
This is a simple change so that `bundleId` passed as a parameter will be used in the client command.
Resolves issue #7 