### PR TITLE
Check host os

### DIFF
--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -125,7 +125,7 @@ module Fastlane
         command << "versionStr=\"#{params[:versionStr]}\""
         command << "version=\"#{params[:version]}\""
         command << symbolFilesCommandSnippet
-        command << "server=\"#{Helper::DynatraceHelper.get_server_base_url(params)}\""
+        command << "server=\"#{Helper::DynatraceHelper.get_host_name(params)}\""
         command << "DTXLogLevel=ALL -verbose" if params[:debugMode] == true
         command << "forced=1" # if the file already exists
 

--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -2,7 +2,8 @@ require 'fastlane/action'
 require 'net/http'
 require 'open-uri'
 require 'zip'
-require "fileutils"
+require 'fileutils'
+require 'os'
 require_relative '../helper/dynatrace_helper'
 
 module Fastlane
@@ -26,64 +27,82 @@ module Fastlane
           UI.message "BundleID: #{bundleId}"
         end
 
+        if params[:os] == "android"
+          response_code = Helper::DynatraceHelper.put_android_symbols(params, bundleId)
+          case response_code
+            when '204'
+              UI.success "Successfully uploaded the mapping file (#{params[:symbolsfile]}) to Dynatrace."
+            when '400'
+              UI.user_error! "Failed to upload. The input is invalid."
+            when '401'
+              UI.user_error! "Invalid Dynatrace API token. See https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/#token-permissions and https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/mobile-symbolication-api/"
+            when '413'
+              UI.user_error! "Failed to upload. The symbol file storage quota is exhausted. See https://www.dynatrace.com/support/help/shortlink/mobile-symbolication#manage-the-uploaded-symbol-files for more information."
+            else
+              UI.user_error! "Unknown upload error (code=#{response_code})." 
+          end
+          return
+        elsif params[:os] != "ios"
+          raise "Unsopported value os=#{params[:os]}"
+        end
+
+        # iOS workflow
         dtxDssClientPath = Helper::DynatraceHelper.get_dss_client(params)
 
         dsym_paths = []
         symbolFilesKey = "symbolsfile" # default to iOS
 
-        if params[:os] == "ios"
-          if params[:downloadDsyms] == true         
-            UI.message "Downloading dSYMs from App Store Connect"
-            startTime = Time.now
+        if !OS.mac?
+          raise "In order to process iOS symbols a macOS machine is required."
+        end
 
-            UI.message "Checking AppFile for possible username/AppleID" 
-            username = CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
-            if username
-              UI.message "Using #{username} from your AppFile" 
-            else
-              username = params[:username]
-              UI.message "Didn't find a username in AppFile, using passed username parameter: #{params[:username]}"
-            end
+        if params[:downloadDsyms] == true         
+          UI.message "Downloading dSYMs from App Store Connect"
+          startTime = Time.now
 
-            # it takes a couple of minutes until the new build is available through the API
-            #  -> retry until available
-            while params[:waitForDsymProcessing] and # wait is active
-                  !lane_context[SharedValues::DSYM_PATHS] and # has dsym path
-                  (Time.now - startTime) < params[:waitForDsymProcessingTimeout] # is in time
-
-              Actions::DownloadDsymsAction.run(wait_for_dsym_processing: params[:waitForDsymProcessing],
-                                              wait_timeout: (params[:waitForDsymProcessingTimeout] - (Time.now - startTime)).round(0), # remaining timeout
-                                              app_identifier: bundleId,
-                                              username: username,
-                                              version: params[:version],
-                                              build_number: params[:versionStr],
-                                              platform: :ios) # should be optional (Hint: it's not)
-
-              if !lane_context[SharedValues::DSYM_PATHS] and (Time.now - startTime) < params[:waitForDsymProcessingTimeout]
-                UI.message "Version #{params[:version]} (Build #{params[:versionStr]}) isn't listed yet, retrying in 60 seconds (timeout in #{(params[:waitForDsymProcessingTimeout] - (Time.now - startTime)).round(0)} seconds)."
-                sleep(60)
-              end
-            end
-
-            if (Time.now - startTime) > params[:waitForDsymProcessingTimeout]
-              UI.user_error!("Timeout during dSYM download. Try increasing :waitForDsymProcessingTimeout.")
-            end
-
-            dsym_paths += Actions.lane_context[SharedValues::DSYM_PATHS] if Actions.lane_context[SharedValues::DSYM_PATHS]
-
-            if dsym_paths.count > 0
-              UI.message "Downloaded the dSYMs from App Store Connect. Paths: #{dsym_paths}"
-            else
-              raise 'No dSYM paths found!'
-            end
+          UI.message "Checking AppFile for possible username/AppleID" 
+          username = CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
+          if username
+            UI.message "Using #{username} from your AppFile" 
           else
-            UI.error "dSYM download disabled, using local path (#{params[:symbolsfile]})"
-            dsym_paths << params[:symbolsfile] if params[:symbolsfile]
+            username = params[:username]
+            UI.message "Didn't find a username in AppFile, using passed username parameter: #{params[:username]}"
           end
 
-        else # android
-           dsym_paths << params[:symbolsfile] if params[:symbolsfile]
-           symbolFilesKey = "file"
+          # it takes a couple of minutes until the new build is available through the API
+          #  -> retry until available
+          while params[:waitForDsymProcessing] and # wait is active
+                !lane_context[SharedValues::DSYM_PATHS] and # has dsym path
+                (Time.now - startTime) < params[:waitForDsymProcessingTimeout] # is in time
+
+            Actions::DownloadDsymsAction.run(wait_for_dsym_processing: params[:waitForDsymProcessing],
+                                            wait_timeout: (params[:waitForDsymProcessingTimeout] - (Time.now - startTime)).round(0), # remaining timeout
+                                            app_identifier: bundleId,
+                                            username: username,
+                                            version: params[:version],
+                                            build_number: params[:versionStr],
+                                            platform: :ios) # should be optional (Hint: it's not)
+
+            if !lane_context[SharedValues::DSYM_PATHS] and (Time.now - startTime) < params[:waitForDsymProcessingTimeout]
+              UI.message "Version #{params[:version]} (Build #{params[:versionStr]}) isn't listed yet, retrying in 60 seconds (timeout in #{(params[:waitForDsymProcessingTimeout] - (Time.now - startTime)).round(0)} seconds)."
+              sleep(60)
+            end
+          end
+
+          if (Time.now - startTime) > params[:waitForDsymProcessingTimeout]
+            UI.user_error!("Timeout during dSYM download. Try increasing :waitForDsymProcessingTimeout.")
+          end
+
+          dsym_paths += Actions.lane_context[SharedValues::DSYM_PATHS] if Actions.lane_context[SharedValues::DSYM_PATHS]
+
+          if dsym_paths.count > 0
+            UI.message "Downloaded the dSYMs from App Store Connect. Paths: #{dsym_paths}"
+          else
+            raise 'No dSYM paths found!'
+          end
+        else
+          UI.error "dSYM download disabled, using local path (#{params[:symbolsfile]})"
+          dsym_paths << params[:symbolsfile] if params[:symbolsfile]
         end
 
         # check if we have dSYMs to proceed with

--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -43,7 +43,7 @@ module Fastlane
           end
           return
         elsif params[:os] != "ios"
-          raise "Unsopported value os=#{params[:os]}"
+          UI.user_error! "Unsopported value os=#{params[:os]}"
         end
 
         # iOS workflow
@@ -53,7 +53,7 @@ module Fastlane
         symbolFilesKey = "symbolsfile" # default to iOS
 
         if !OS.mac?
-          raise "In order to process iOS symbols a macOS machine is required."
+          UI.user_error! "A macOS machine is required to process iOS symbols."
         end
 
         if params[:downloadDsyms] == true         

--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -101,7 +101,7 @@ module Fastlane
             raise 'No dSYM paths found!'
           end
         else
-          UI.error "dSYM download disabled, using local path (#{params[:symbolsfile]})"
+          UI.important "dSYM download disabled, using local path (#{params[:symbolsfile]})"
           dsym_paths << params[:symbolsfile] if params[:symbolsfile]
         end
 
@@ -125,7 +125,7 @@ module Fastlane
         command << "versionStr=\"#{params[:versionStr]}\""
         command << "version=\"#{params[:version]}\""
         command << symbolFilesCommandSnippet
-        command << "server=\"#{Helper::DynatraceHelper.get_host_name(params)}\""
+        command << "server=\"#{Helper::DynatraceHelper.get_base_url(params)}\""
         command << "DTXLogLevel=ALL -verbose" if params[:debugMode] == true
         command << "forced=1" # if the file already exists
 

--- a/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
+++ b/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
@@ -1,6 +1,6 @@
 require 'fastlane_core/ui/ui'
 require 'digest'
-require 'net/https'
+require 'net/http'
 require 'tempfile'
 require 'uri'
 

--- a/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
+++ b/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
@@ -142,9 +142,7 @@ module Fastlane
         req.body = IO.read(params[:symbolsfile])
         http = Net::HTTP.new(self.get_host_name(params), 443)
         http.use_ssl = true
-        response = http.request(req)
-
-        response.code
+        http.request(req)
       end
 
       private

--- a/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
+++ b/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
@@ -21,7 +21,7 @@ module Fastlane
         end
 
         # get latest version info
-        clientUri = URI("#{self.get_server_base_url(params)}/api/config/v1/symfiles/dtxdss-download?Api-Token=#{params[:apitoken]}")
+        clientUri = URI("#{self.get_host_name(params)}/api/config/v1/symfiles/dtxdss-download?Api-Token=#{params[:apitoken]}")
         response = Net::HTTP.get_response(clientUri)
 
         # filter any http errors
@@ -113,11 +113,18 @@ module Fastlane
         return dtxDssClientPath
       end
 
-      def self.get_server_base_url(params)
-        if params[:server][-1] == '/'
-          return params[:server][0..-2]
+      def self.get_host_name(params)
+        uri = URI.split(params[:server])
+
+        unless uri[2].nil?
+          return uri[2]
+        end
+
+        # no procotol prefix -> host name is with path
+        if uri[5][-1] == '/'
+          return uri[5][0..-2] # remove trailing /
         else
-          return params[:server]
+          return uri[5]
         end
       end
 
@@ -128,7 +135,7 @@ module Fastlane
                                                       'Authorization' => "Api-Token #{params[:apitoken]}"} )
 
         req.body = IO.read(params[:symbolsfile])
-        http = Net::HTTP.new(self.get_server_base_url(params), 443)
+        http = Net::HTTP.new(self.get_host_name(params), 443)
         http.use_ssl = true
         response = http.request(req)
 

--- a/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
+++ b/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
@@ -1,9 +1,8 @@
 require 'fastlane_core/ui/ui'
 require 'digest'
-require 'net/http'
+require 'net/https'
 require 'tempfile'
 require 'uri'
-
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
@@ -120,6 +119,20 @@ module Fastlane
         else
           return params[:server]
         end
+      end
+
+      def self.put_android_symbols(params, bundleId)
+        path = "/api/config/v1/symfiles/#{params[:appId]}/#{bundleId}/ANDROID/#{params[:version]}/#{params[:versionStr]}"
+
+        req = Net::HTTP::Put.new(path, initheader = { 'Content-Type' => 'text/plain',
+                                                      'Authorization' => "Api-Token #{params[:apitoken]}"} )
+
+        req.body = IO.read(params[:symbolsfile])
+        http = Net::HTTP.new(self.get_server_base_url(params), 443)
+        http.use_ssl = true
+        response = http.request(req)
+
+        response.code
       end
 
       private

--- a/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
+++ b/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
@@ -21,7 +21,7 @@ module Fastlane
         end
 
         # get latest version info
-        clientUri = URI("#{self.get_host_name(params)}/api/config/v1/symfiles/dtxdss-download?Api-Token=#{params[:apitoken]}")
+        clientUri = URI("#{self.get_base_url(params)}/api/config/v1/symfiles/dtxdss-download?Api-Token=#{params[:apitoken]}")
         response = Net::HTTP.get_response(clientUri)
 
         # filter any http errors
@@ -111,6 +111,11 @@ module Fastlane
           end
         end
         return dtxDssClientPath
+      end
+
+      def self.get_base_url(params)
+        uri = URI.split(params[:server])
+        return uri[0] + '://' + uri[2]
       end
 
       def self.get_host_name(params)

--- a/spec/dynatrace_action_spec.rb
+++ b/spec/dynatrace_action_spec.rb
@@ -1,0 +1,231 @@
+require 'open-uri'
+
+describe Fastlane::Actions::DynatraceProcessSymbolsAction do
+  describe ".run" do
+    context "processing symbols of unknown system" do
+        it "can't process" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)
+
+            dict = { :apitoken => "",
+                     :os => "windows_mobile_lol",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)
+
+            expect{
+                Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError)
+        end
+    end
+
+    context "ios: non-macOS machine" do
+        it "can't run on inferiour OSs" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)
+
+            dict = { :apitoken => "",
+                     :os => "ios",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)
+
+            expect(OS).to receive(:mac?).and_return(false)
+
+            expect{
+                Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError)
+        end
+    end
+
+    context "android: full valid workflow" do
+        it "uploads a local symbol file" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)
+
+            dict = { :apitoken => "",
+                     :os => "android",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)
+
+            response = Net::HTTPSuccess.new(1.0, '204', 'OK')
+            expect_any_instance_of(Net::HTTP).to receive(:request) { response }
+
+            Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+        end
+    end
+
+    context "android: failing upload" do
+        it "uploads a local symbol file but has an error" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)    
+
+            dict = { :apitoken => "",
+                     :os => "android",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }    
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)    
+
+            response = Net::HTTPSuccess.new(1.0, '400', 'Bad Request')
+            expect_any_instance_of(Net::HTTP).to receive(:request) { response }    
+
+            expect{
+                Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+        it "uploads a local symbol file but auth token is valid" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)    
+
+            dict = { :apitoken => "",
+                     :os => "android",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }    
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)    
+
+            response = Net::HTTPSuccess.new(1.0, '401', 'Unauthorized')
+            expect_any_instance_of(Net::HTTP).to receive(:request) { response }    
+
+            expect{
+                Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError)
+        end  
+
+        it "uploads a local symbol file but quota is exceeded" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)    
+
+            dict = { :apitoken => "",
+                     :os => "android",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }    
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)    
+
+            response = Net::HTTPSuccess.new(1.0, '413', 'Quota Exceeded')
+            expect_any_instance_of(Net::HTTP).to receive(:request) { response }    
+
+            expect{
+                Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError)
+        end
+
+        it "uploads a local symbol file but has an unknown error response" do
+            # mock config
+            apitoken = FastlaneCore::ConfigItem.new(key: :apitoken, type: String, optional: false)
+            os = FastlaneCore::ConfigItem.new(key: :os, type: String, optional: false)
+            versionStr = FastlaneCore::ConfigItem.new(key: :versionStr, type: String, optional: false)
+            version = FastlaneCore::ConfigItem.new(key: :version, type: String, optional: false)
+            server = FastlaneCore::ConfigItem.new(key: :server, type: String, optional: false)
+            bundleId = FastlaneCore::ConfigItem.new(key: :bundleId, type: String, optional: false)
+            symbolsfile = FastlaneCore::ConfigItem.new(key: :symbolsfile, type: String, optional: false)
+            dtxDssClientPath = FastlaneCore::ConfigItem.new(key: :dtxDssClientPath, type: String, optional: false)
+            appId = FastlaneCore::ConfigItem.new(key: :appId, type: String, optional: false)    
+
+            dict = { :apitoken => "",
+                     :os => "android",
+                     :versionStr => "123",
+                     :version => "456",
+                     :server => "https://dynatrace.com",
+                     :bundleId => "com.dynatrace.fastlanetest",
+                     :symbolsfile => Dir.pwd + "/spec/testdata/android-mapping-test.txt",
+                     :dtxDssClientPath => "",
+                     :appId => "abcdefg" }    
+
+            flhash = FastlaneCore::Configuration.create([apitoken, os, versionStr, version, server, bundleId, symbolsfile, dtxDssClientPath, appId], dict)    
+
+            response = Net::HTTPSuccess.new(1.0, '444', 'Idk')
+            expect_any_instance_of(Net::HTTP).to receive(:request) { response }    
+
+            expect{
+                Fastlane::Actions::DynatraceProcessSymbolsAction.run(flhash)
+            }.to raise_error(FastlaneCore::Interface::FastlaneError)
+        end
+    end
+  end
+end

--- a/spec/dynatrace_helper_spec.rb
+++ b/spec/dynatrace_helper_spec.rb
@@ -407,18 +407,18 @@ describe Fastlane::Helper::DynatraceHelper do
     end
   end
 
-  describe ".get_server_base_url" do
+  describe ".get_host_name" do
     context "given 'https://dynatrace.com/'" do
-      it "returns https://dynatrace.com" do
+      it "returns dynatrace.com" do
         dict = { :server => "https://dynatrace.com/" }
-        expect(Fastlane::Helper::DynatraceHelper.get_server_base_url(dict)).to eql("https://dynatrace.com")
+        expect(Fastlane::Helper::DynatraceHelper.get_host_name(dict)).to eql("dynatrace.com")
       end
     end
 
-    context "given 'https://dynatrace.com'" do
-      it "returns https://dynatrace.com" do
-        dict = { :server => "https://dynatrace.com" }
-        expect(Fastlane::Helper::DynatraceHelper.get_server_base_url(dict)).to eql("https://dynatrace.com")
+    context "given 'dynatrace.com/'" do
+      it "returns dynatrace.com" do
+        dict = { :server => "dynatrace.com/" }
+        expect(Fastlane::Helper::DynatraceHelper.get_host_name(dict)).to eql("dynatrace.com")
       end
     end
   end

--- a/spec/dynatrace_helper_spec.rb
+++ b/spec/dynatrace_helper_spec.rb
@@ -407,6 +407,15 @@ describe Fastlane::Helper::DynatraceHelper do
     end
   end
 
+  describe ".get_base_url" do
+    context "given 'https://dynatrace.com/'" do
+      it "returns https://dynatrace.com" do
+        dict = { :server => "https://dynatrace.com/" }
+        expect(Fastlane::Helper::DynatraceHelper.get_base_url(dict)).to eql("https://dynatrace.com")
+      end
+    end
+  end
+
   describe ".get_host_name" do
     context "given 'https://dynatrace.com/'" do
       it "returns dynatrace.com" do

--- a/spec/testdata/android-mapping-test.txt
+++ b/spec/testdata/android-mapping-test.txt
@@ -1,0 +1,1 @@
+Your ad could be here.


### PR DESCRIPTION
- Add check to execute iOS symbol processing only on macOS systems.
- Upload Android symbols directly via API in order to support Linux.