### PR TITLE
Managed url parsing bug

### DIFF
--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -131,7 +131,7 @@ module Fastlane
         command << "versionStr=\"#{params[:versionStr]}\""
         command << "version=\"#{params[:version]}\""
         command << symbolFilesCommandSnippet
-        command << "server=\"#{Helper::DynatraceHelper.get_base_url(params)}\""
+        command << "server=\"#{Helper::DynatraceHelper.without_trailing_slash(params[:server])}\""
         command << "DTXLogLevel=ALL -verbose" if params[:debugMode] == true
         command << "forced=1" # if the file already exists
 

--- a/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
+++ b/lib/fastlane/plugin/dynatrace/actions/dynatrace_action.rb
@@ -40,7 +40,10 @@ module Fastlane
             when '413'
               UI.user_error! "Failed to upload. The symbol file storage quota is exhausted. See https://www.dynatrace.com/support/help/shortlink/mobile-symbolication#manage-the-uploaded-symbol-files for more information."
             else
-              message = JSON.parse(response.body)["error"]["message"]
+              message = nil
+              unless response.body.nil?
+                message = JSON.parse(response.body)["error"]["message"]
+              end
               if message.nil?
                 UI.user_error! "Symbol upload error (Response Code: #{response.code}). Please try again in a few minutes or contact the Dynatrace support (https://www.dynatrace.com/services-support/)." 
               else

--- a/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
+++ b/lib/fastlane/plugin/dynatrace/helper/dynatrace_helper.rb
@@ -143,7 +143,7 @@ module Fastlane
         if params[:server].include? '/e/'
           uri = URI.split(params[:server])
           if uri[5].nil?
-            UI.user_error! "The path component of your managed Dynatrace URL is empty. Does does server URL follow the correct pattern (https://{your-domain}/e/{your-environment-id})?"
+            UI.user_error! "The path component of your managed Dynatrace URL is empty. Does the server URL follow the correct pattern (https://{your-domain}/e/{your-environment-id})?"
           end
           path = self.without_trailing_slash(uri[5]) + path
         end

--- a/spec/dynatrace_helper_spec.rb
+++ b/spec/dynatrace_helper_spec.rb
@@ -407,11 +407,22 @@ describe Fastlane::Helper::DynatraceHelper do
     end
   end
 
-  describe ".get_base_url" do
+  describe ".without_trailing_slash" do
     context "given 'https://dynatrace.com/'" do
       it "returns https://dynatrace.com" do
-        dict = { :server => "https://dynatrace.com/" }
-        expect(Fastlane::Helper::DynatraceHelper.get_base_url(dict)).to eql("https://dynatrace.com")
+        expect(Fastlane::Helper::DynatraceHelper.without_trailing_slash("https://dynatrace.com/")).to eql("https://dynatrace.com")
+      end
+    end
+
+    context "given 'https://your-domain.com/e/your-environment-id/'" do
+      it "returns https://your-domain.com/e/your-environment-id" do
+        expect(Fastlane::Helper::DynatraceHelper.without_trailing_slash("https://your-domain.com/e/your-environment-id/")).to eql("https://your-domain.com/e/your-environment-id")
+      end
+    end
+
+    context "given 'https://your-domain.com/e/your-environment-id'" do
+      it "returns https://your-domain.com/e/your-environment-id" do
+        expect(Fastlane::Helper::DynatraceHelper.without_trailing_slash("https://your-domain.com/e/your-environment-id")).to eql("https://your-domain.com/e/your-environment-id")
       end
     end
   end
@@ -428,6 +439,13 @@ describe Fastlane::Helper::DynatraceHelper do
       it "returns dynatrace.com" do
         dict = { :server => "dynatrace.com/" }
         expect(Fastlane::Helper::DynatraceHelper.get_host_name(dict)).to eql("dynatrace.com")
+      end
+    end
+
+    context "given 'https://your-domain.com/e/your-environment-id/api/blablub'" do
+      it "returns your-domain.com" do
+        dict = { :server => "https://your-domain.com/e/your-environment-id/api/blablub" }
+        expect(Fastlane::Helper::DynatraceHelper.get_host_name(dict)).to eql("your-domain.com")
       end
     end
   end


### PR DESCRIPTION
- Changed the URL parsing to support the managed syntax (https://www.dynatrace.com/support/help/dynatrace-api/configuration-api/mobile-symbolication-api/put-files-app-version/). Previously the "/e/environment-id" was stripped, because it's part of the path which Ruby does not allow to be included in host resolution.

- Updated tests for improved JSON errors code parsing from API.