### PR TITLE
Bitcode support code removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,67 +11,14 @@ fastlane add_plugin dynatrace
 ```
 
 ## About the Dynatrace fastlane plugin
-The Dynatrace fastlane plugin manages uploading symbol files (iOS, tvOS) or obfuscation mapping files (Android) to the Dynatrace cluster. Symbol and mapping files are used to make reported stack traces human-readable. The plugin also allows to download the latest dSYM files from App Store Connect, which enables full automation of the mobile app deployment, and the pre-processing of dSYM files, a step that is necessary for the Dynatrace cluster to be able to symbolicate.
+The Dynatrace fastlane plugin manages pre-processing and uploading of dSYM files (iOS, tvOS) or uploading of obfuscation mapping files (Android) to the Dynatrace cluster. Symbol and mapping files are used to make reported stack traces human-readable.
 
-The plugin provides a single action `dynatrace_process_symbols`. The configuration depends on whether the app is (A) iOS and Bitcode-enabled or (B) iOS/tvOS and not Bitcode-enabled or an Android app.
-
-For Bitcode-enabled iOS apps we recommend to let the plugin handle the download of the dSYM files from App Store Connect and upload to Dynatrace.
-
+The plugin provides a single action `dynatrace_process_symbols`. The configuration depends on whether the app is an iOS/tvOS or an Android app.
 
 ## Usage
-To get started, ask your Dynatrace administrator for an [API token ](https://www.dynatrace.com/support/help/shortlink/api-authentication) with **Mobile symbolication file management** permission . To generate the API token, go to **Integration** > **Dynatrace API**.  The token is used by the authenticate the plugin into Dynatrace and upload the symbol and mapping files.
+To get started, ask your Dynatrace administrator for an [API token ](https://www.dynatrace.com/support/help/shortlink/api-authentication) with **Mobile symbolication file management** permission . To generate the API token, go to **Integration** > **Dynatrace API**. The token is used by the authenticate the plugin into Dynatrace and upload the symbol and mapping files.
 
-Add the action `dynatrace_process_symbols` to your Fastfile. You'll find all the configuration options and a default configuration later in the readme.
-
-Now, when you run fastlane, the Dynatrace plugin will manage the symbol files of your app as configured.
-
-### Dynatrace Managed (1.195 and earlier)
-For cluster versions 1.195 and earlier, the Dynatrace application 'Symbolication Client' has to be downloaded manually and explicitly specified (`dtxDssClientPath`). For all cluster versions above 1.195 it is fetched and updated automatically. A matching version can be downloaded manually with this link [https://api.mobileagent.downloads.dynatrace.com/sprint-latest-dss-client/xyz](https://api.mobileagent.downloads.dynatrace.com/sprint-latest-dss-client/xyz) by replacing `xyz` with the 3-digit sprint version of your Dynatrace Managed installation.
-
-
-## A) Bitcode-enabled iOS apps
-This is the right approach if your app is distributed via Apple's App Store or TestFlight and Bitcode-enabled. For all other cases, follow the approach B below.
-
-Background: If your app is Bitcode-enabled, then the dSYMs that are generated during the Xcode build are **not** the dSYMs that need to be uploaded to Dynatrace. Apple recompiles the application on their servers, generating new dSYM files in the process. These newly generated dSYM files need to be downloaded from *App Store Connect*, processed and uploaded to Dynatrace.
-
-### Automatically downloading dSYMs
-
-To fully automate the following five-step workflow, add the snippets below to the respective files and fill in the placeholders. Uploading the app to App Store Connect is a necessary prerequisite and either handled manually or by fastlane directly:
-
-1. Wait until the build is processed
-2. Download the resulting dSYM files
-3. Process dSYM files into the format that Dynatrace requires
-4. Upload processed dSYM files to Dynatrace
-
-#### Fastfile
-```ruby
-dynatrace_process_symbols(
-	appId: "<Dynatrace application ID>",
-	apitoken: "<Dynatrace API token>",
-	os: "ios",
-	bundleId: "<CFBundlebundleId>",
-	versionStr: "<Build Number (CFBundleVersion)>",
-	version: "<App Version (CFBundleShortVersionString)>",
-	server: "<Dynatrace Environment URL>",
-	downloadDsyms: true
-)
-```
-
-#### Waiting time between app upload and dSYM file download
-After a completed upload to App Store Connect, there is some waiting time before the dSYM files are ready to be downloaded. The Dynatrace fastlane plugin waits and downloads the symbol files if setting the `waitForDsymProcessing` is true and a waiting period is provided via `waitForDsymProcessingTimeout`. We recommend 1800 seconds (30 mins) as the default waiting time. In our experience, this is sufficiently long for the processing to happen. If this duration is not long enough, you need to increase it. 
-
-> Note: this timeout is the **maximum** waiting time. If the symbol files are ready sooner, the plugin will continue to the download and will not wait for the whole duration of the timeout.
-
-
-## B) Not Bitcode-enabled iOS/tvOS apps or Android apps
-If at least one of the following conditions is true, you should follow this approach:
-
-* **not** using Bitcode for your iOS/tvOS app
-* already downloaded the new symbol files from App Store Connect manually
-* deploy an Android app
-
-#### Fastfile
-Use the parameter `symbolsfile` to provide a relative path to the symbols file.
+Add the action `dynatrace_process_symbols` to your Fastfile. You'll find all the configuration options and a default configuration below. Use the parameter `symbolsfile` to provide a relative path to the symbols file (dSYM or Android mapping).
 
 ```ruby
 dynatrace_process_symbols(
@@ -86,38 +33,26 @@ dynatrace_process_symbols(
 )
 ```
 
+Now, when you run fastlane, the Dynatrace plugin will manage the symbol files of your app as configured.
+
+
 ## List of all Parameters
 | Key                          | Description                                                                                                                                                           | default value  |
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
 | action                       | *(iOS/tvOS only)* Action to be performed by DTXDssClient (`upload` or `decode`).                                                                                           | `upload`       |
-| downloadDsyms                | *(iOS/tvOS only)* Download the dSYMs from App Store Connect.                                                                                                               | `false`        |
-| waitForDsymProcessing        | *(iOS/tvOS only)* Wait for dSYM processing to be finished.                                                                                                                  | `true`         |
-| waitForDsymProcessingTimeout | *(iOS/tvOS only)* Timeout in seconds to wait for the dSYMs be downloadable.                                                                                                | `1800`         |
 | username                     | *(iOS/tvOS only)* The username/AppleID to use to download the dSYMs. Alternatively you can specify this in your AppFile as `apple_id`.                                     |                |
 | os                           | The type of the symbol files, either `ios`, `tvOS` or `android`.                                                                                                              |                |
 | apitoken                     | Dynatrace API token with mobile symbolication permissions.                                                                                                            |                |
-| dtxDssClientPath             | **(DEPRECATED)** The path to your DTXDssClient. The DTXDssClient is downloaded and updated automatically, unless this key is set.                                     |                |
 | appID                        | The application ID you get from your Dynatrace environment.                                                                                                           |                |
 | bundleId                     | The CFBundlebundleId (iOS, tvOS) / package (Android) of the application. Alternatively you can specify this in your AppFile as `app_identifier`.                            |                |
 | versionStr                   | The CFBundleShortVersionString (iOS, tvOS) / versionName (Android)                                                                                                          |                |
 | version                      | The CFBundleVersion (iOS, tvOS) / versionCode (Android). Is also used for the dSYM download.                                                                                |                |
-| symbolsfile                  | Path to the dSYM file to be processed. If downloadDsyms is set, this is only a fallback.                                                                              |                |
+| symbolsfile                  | Path to the dSYM or Android mapping file to be processed. *(Android only)*: If the file exceeds 10MiB and doesn't end with `*.zip` it's zipped before uploading. This can be disabled by setting `symbolsfileAutoZip` to false.                                                                             |                |
 | symbolsfileAutoZip           | *(Android only)* Automatically zip symbolsfile if it exceeds 10MiB and doesn't already end with `*.zip`.                                                                              | `true` |
 | server                       | The API endpoint for the Dynatrace environment (e.g. `https://environmentID.live.dynatrace.com` or `https://dynatrace-managed.com/e/environmentID`).                  |                |
-| cleanBuildArtifacts          | Clean build artifacts after processing.                                                                                         | `true`         |
+| cleanBuildArtifacts          | Clean build artifacts after processing.                                                                                         | `false`         |
 | tempdir                      | (OPTIONAL) Custom temporary directory for the DTXDssClient. **The plugin does not take care of cleaning this directory.**                                                                                         |                |
 | debugMode                    | Enable debug logging.                                                                                                                                                 | false          |
-
-
-### Fastlane Session
-The full documentation for this can be found on the [fastlane docs](https://docs.fastlane.tools/best-practices/continuous-integration/#two-step-or-two-factor-auth
-) under **spaceauth**.
-
-You can generate a session by running `fastlane spaceauth -u user@email.com` on your machine and copy the output into an environment variable `FASTLANE_SESSION` on the target system (e.g. CI).
-
-> Note: 
-> - Session is only valid for the "region" you created it in. If your CI is in a different geographical location, the authentication might fail
-> - Generated sessions are valid for up to one month. Apple's API doesn't specify details about that, so it is only noticable by a failing build
 
 ## Example
 Try it by cloning the repo, running `fastlane install_plugins` and `bundle exec fastlane test`.

--- a/fastlane-plugin-dynatrace.gemspec
+++ b/fastlane-plugin-dynatrace.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.email         = 'mobile.agent@dynatrace.com'
 
   spec.summary       = 'This action processes and uploads your symbol files to Dynatrace'
-  spec.homepage      = "https://github.com/Dynatrace/fastlane-plugin-dynatrace"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/Dynatrace/fastlane-plugin-dynatrace'
+  spec.license       = 'Apache 2.0'
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})

--- a/lib/fastlane/plugin/dynatrace/version.rb
+++ b/lib/fastlane/plugin/dynatrace/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Dynatrace
-    VERSION = "1.0.8"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
- removed appstore connect download (due to bitcode deprecation on 1st of april)
- removed deprecated parameter downloadDsyms
- removed deprecated parameter waitForDsymProcessing
- removed deprecated parameter waitForDsymProcessingTimeout
- removed deprecated parameter dtxDssClientPath
- set cleanBuildArtifacts default to false
- bumped version to 2.0.0
- updated readme accordingly
- changed license to apache 2.0 (to sync with the repo)